### PR TITLE
Remove distclean dep for repoclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ clean:
 distclean: clean
 	-rm -rf $(TARGET_GUI) $(TARGET_CLI)
 
-repoclean: distclean
+repoclean:
 	git clean -ffd
 
 $(BUILD_PATH)/tests: $(TESTS_OBJS) $(COMMON_LIB)


### PR DESCRIPTION
Having `distclean` as a dependency for `repoclean` seemed excessive. `git clean -ffd` will do all that `make distclean` would do and more.
```
vizio> make repoclean
rm -rf build
rm -rf QDmrconfig dmrconfig
git clean -ffd
vizio> git co repoclean_update
vizio> make repoclean
git clean -ffd
vizio>
```