### PR TITLE
Style format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -18,5 +18,5 @@ BeforeCatch: true,
 SplitEmptyFunction: true,
 SplitEmptyRecord: true,
 AfterFunction: true,
-AfterCaseLabel: false,
+AfterCaseLabel: true,
 }

--- a/.clang-format
+++ b/.clang-format
@@ -18,4 +18,5 @@ BeforeCatch: true,
 SplitEmptyFunction: true,
 SplitEmptyRecord: true,
 AfterFunction: true,
+AfterCaseLabel: false,
 }

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+BasedOnStyle : Google
+ColumnLimit : 0
+AccessModifierOffset : -2
+BreakConstructorInitializers : AfterColon
+DerivePointerAlignment : false
+PointerAlignment : Left
+BinPackArguments : true
+FixNamespaceComments : true
+MaxEmptyLinesToKeep : 1
+AllowShortIfStatementsOnASingleLine : false
+AllowShortFunctionsOnASingleLine : None
+BreakBeforeBraces: Custom
+BraceWrapping : {
+AfterClass: true,
+BeforeElse: true,
+AfterControlStatement: true,
+BeforeCatch: true,
+SplitEmptyFunction: true,
+SplitEmptyRecord: true,
+AfterFunction: true,
+}

--- a/.clang-format
+++ b/.clang-format
@@ -1,21 +1,181 @@
-BasedOnStyle : Google
-ColumnLimit : 0
-AccessModifierOffset : -2
-BreakConstructorInitializers : AfterColon
-DerivePointerAlignment : false
-PointerAlignment : Left
-BinPackArguments : true
-FixNamespaceComments : true
-MaxEmptyLinesToKeep : 1
-AllowShortIfStatementsOnASingleLine : false
-AllowShortFunctionsOnASingleLine : None
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+# AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+# AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+# AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+# AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+#  AfterCaseLabel:  false
+  AfterClass:      true
+#  AfterControlStatement: Always
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+#  BeforeLambdaBody: false
+#  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
-BraceWrapping : {
-AfterClass: true,
-BeforeElse: true,
-AfterControlStatement: true,
-BeforeCatch: true,
-SplitEmptyFunction: true,
-SplitEmptyRecord: true,
-AfterFunction: true,
-}
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+#    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+#    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+#    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+#    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,181 +1,21 @@
----
-Language:        Cpp
-AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
-AlignConsecutiveMacros: false
-AlignConsecutiveAssignments: false
-AlignConsecutiveBitFields: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Left
-# AlignOperands:   Align
-AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
-AllowAllConstructorInitializersOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortEnumsOnASingleLine: true
-# AllowShortBlocksOnASingleLine: Never
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: All
-# AllowShortIfStatementsOnASingleLine: Never
-AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-# AlwaysBreakTemplateDeclarations: Yes
-BinPackArguments: true
-BinPackParameters: true
-BraceWrapping:
-#  AfterCaseLabel:  false
-  AfterClass:      true
-#  AfterControlStatement: Always
-  AfterEnum:       false
-  AfterFunction:   true
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     true
-  BeforeElse:      true
-#  BeforeLambdaBody: false
-#  BeforeWhile:     false
-  IndentBraces:    false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
+BasedOnStyle : Google
+ColumnLimit : 0
+AccessModifierOffset : -2
+BreakConstructorInitializers : AfterColon
+DerivePointerAlignment : false
+PointerAlignment : Left
+BinPackArguments : true
+FixNamespaceComments : true
+MaxEmptyLinesToKeep : 1
+AllowShortIfStatementsOnASingleLine : false
+AllowShortFunctionsOnASingleLine : None
 BreakBeforeBraces: Custom
-BreakBeforeInheritanceComma: false
-BreakInheritanceList: BeforeColon
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: AfterColon
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: true
-ColumnLimit:     0
-CommentPragmas:  '^ IWYU pragma:'
-CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DeriveLineEnding: true
-DerivePointerAlignment: false
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: true
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IncludeBlocks:   Regroup
-IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
-    Priority:        2
-#    SortPriority:    0
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-#    SortPriority:    0
-  - Regex:           '^<.*'
-    Priority:        2
-#    SortPriority:    0
-  - Regex:           '.*'
-    Priority:        3
-#    SortPriority:    0
-IncludeIsMainRegex: '([-_](test|unittest))?$'
-IncludeIsMainSourceRegex: ''
-IndentCaseLabels: true
-IndentCaseBlocks: false
-IndentGotoLabels: true
-IndentPPDirectives: None
-IndentExternBlock: AfterExternBlock
-IndentWidth:     2
-IndentWrappedFunctionNames: false
-InsertTrailingCommas: None
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBinPackProtocolList: Never
-ObjCBlockIndentWidth: 2
-ObjCBreakBeforeNestedBlockParam: true
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyBreakTemplateDeclaration: 10
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
-RawStringFormats:
-  - Language:        Cpp
-    Delimiters:
-      - cc
-      - CC
-      - cpp
-      - Cpp
-      - CPP
-      - 'c++'
-      - 'C++'
-    CanonicalDelimiter: ''
-    BasedOnStyle:    google
-  - Language:        TextProto
-    Delimiters:
-      - pb
-      - PB
-      - proto
-      - PROTO
-    EnclosingFunctions:
-      - EqualsProto
-      - EquivToProto
-      - PARSE_PARTIAL_TEXT_PROTO
-      - PARSE_TEST_PROTO
-      - PARSE_TEXT_PROTO
-      - ParseTextOrDie
-      - ParseTextProtoOrDie
-      - ParseTestProto
-      - ParsePartialTestProto
-    CanonicalDelimiter: ''
-    BasedOnStyle:    google
-ReflowComments:  true
-SortIncludes:    true
-SortUsingDeclarations: true
-SpaceAfterCStyleCast: false
-SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: true
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeCpp11BracedList: false
-SpaceBeforeCtorInitializerColon: true
-SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
-SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyBlock: false
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
-SpacesInAngles:  false
-SpacesInConditionalStatement: false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-SpaceBeforeSquareBrackets: false
-Standard:        Auto
-StatementMacros:
-  - Q_UNUSED
-  - QT_REQUIRE_VERSION
-TabWidth:        8
-UseCRLF:         false
-UseTab:          Never
-WhitespaceSensitiveMacros:
-  - STRINGIZE
-  - PP_STRINGIZE
-  - BOOST_PP_STRINGIZE
-...
-
+BraceWrapping : {
+AfterClass: true,
+BeforeElse: true,
+AfterControlStatement: true,
+BeforeCatch: true,
+SplitEmptyFunction: true,
+SplitEmptyRecord: true,
+AfterFunction: true,
+}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -42,7 +42,5 @@ jobs:
       run: git tag -a v1.0 -m "workflow"
     - name: Installing deps
       run: sudo apt-get -y install clang-format
-    - name: Branch name
-      run: echo running on branch ${GITHUB_REF##*/}
     - name: Run style-check
       run: make -j build/style-check

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -28,7 +28,6 @@ jobs:
       run: sudo apt-get -y install libudev-dev libmongoc-dev libusb-1.0-0-dev qt5-default g++-10
     - name: Run checks
       run: make -j check
-
   style-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -41,6 +41,6 @@ jobs:
     - name: Tag repo
       run: git tag -a v1.0 -m "workflow"
     - name: Installing deps
-      run: sudo apt-get -y clang-format
+      run: sudo apt-get -y install clang-format
     - name: Run style-check
       run: make -j build/style-check

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -42,5 +42,7 @@ jobs:
       run: git tag -a v1.0 -m "workflow"
     - name: Installing deps
       run: sudo apt-get -y install clang-format
+    - name: Branch name
+      run: echo running on branch ${GITHUB_REF##*/}
     - name: Run style-check
       run: make -j build/style-check

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -9,15 +9,13 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set Email
-      run: git config --global user.email "you@example.com"
+      run: git config --global user.email "action@example.com"
     - name: Set name
-      run: git config --global user.name "Your Name"
+      run: git config --global user.name ""
     - name: Grab those submodules
       run: git submodule update --init --recursive
     - name: Tag repo
@@ -31,3 +29,20 @@ jobs:
     - name: Run checks
       run: make -j check
 
+  style-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set Email
+      run: git config --global user.email "action@example.com"
+    - name: Set name
+      run: git config --global user.name ""
+    - name: Grab those submodules
+      run: git submodule update --init --recursive
+    - name: Tag repo
+      run: git tag -a v1.0 -m "workflow"
+    - name: Update repos
+    - name: Installing deps
+      run: sudo apt-get -y clang-format
+    - name: Run style-check
+      run: make -j build/style-check

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -40,7 +40,6 @@ jobs:
       run: git submodule update --init --recursive
     - name: Tag repo
       run: git tag -a v1.0 -m "workflow"
-    - name: Update repos
     - name: Installing deps
       run: sudo apt-get -y clang-format
     - name: Run style-check

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set Email
-      run: git config --global user.email "action@example.com"
+      run: git config --global user.email "action@github.com"
     - name: Set name
       run: git config --global user.name "Github Action"
     - name: Grab those submodules

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set Email
       run: git config --global user.email "action@example.com"
     - name: Set name
-      run: git config --global user.name ""
+      run: git config --global user.name "Github Action"
     - name: Grab those submodules
       run: git submodule update --init --recursive
     - name: Tag repo
@@ -35,7 +35,7 @@ jobs:
     - name: Set Email
       run: git config --global user.email "action@example.com"
     - name: Set name
-      run: git config --global user.name ""
+      run: git config --global user.name "Github Action"
     - name: Grab those submodules
       run: git submodule update --init --recursive
     - name: Tag repo

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -42,5 +42,7 @@ jobs:
       run: git tag -a v1.0 -m "workflow"
     - name: Installing deps
       run: sudo apt-get -y install clang-format
+    - name: Update .clang-format
+      run: sed -r -i '/AfterCaseLabel/d' .clang-format
     - name: Run style-check
       run: make -j build/style-check

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,9 @@ $(BUILD_PATH)/run-dmrconfig-tests: $(TARGET_CLI) $(TEST_SCRIPTS)
 	./src/tests/btechTests examples/btech6x2.img.bak
 	@touch $@
 
+$(BUILD_PATH)/style-tests: $(GUI_SRCS) $(COMMON_SRCS) $(TESTS_SRCS)
+	clang-format -i  $^
+
 check: $(BUILD_PATH)/run-tests $(BUILD_PATH)/run-dmrconfig-tests $(TARGET_GUI)
 	@echo -e "\e[32mAll Checks Passed\e[0m"
 

--- a/Makefile
+++ b/Makefile
@@ -129,10 +129,10 @@ $(BUILD_PATH)/run-dmrconfig-tests: $(TARGET_CLI) $(TEST_SCRIPTS)
 #Not required but good to have
 $(BUILD_PATH)/style-check: $(GUI_SRCS) $(GUI_HDRS) $(TESTS_SRCS) $(TESTS_HDRS) $(COMMON_SRCS) $(COMMON_HDRS)
 	clang-format -i $^
-	if [ "`git diff --name-only  | wc -l`" != "0" ]; then \
-		git commit -a -m "Style compliance fixes"; \
-	  git remote -v; \
-		git push origin; \
+	@if [ "`git diff --name-only  | wc -l`" != "0" ]; then \
+		echo "Non compliant with style:"; \
+		git diff --name-only; \
+		exit 1;\
 	fi
 
 check: $(BUILD_PATH)/run-tests $(BUILD_PATH)/run-dmrconfig-tests $(TARGET_GUI)

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ $(BUILD_PATH)/run-dmrconfig-tests: $(TARGET_CLI) $(TEST_SCRIPTS)
 #Not required but good to have
 $(BUILD_PATH)/style-check: $(GUI_SRCS) $(GUI_HDRS) $(TESTS_SRCS) $(TESTS_HDRS) $(COMMON_SRCS) $(COMMON_HDRS)
 	clang-format -i $^
-	@if [ "`git diff --name-only  | wc -l`" != "0" ]; then \
+	@if [ "`git diff --name-only  | wc -l`" -gt "1" ]; then \
 		echo "Non compliant with style:"; \
 		git diff --name-only; \
 		git diff; \

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ $(BUILD_PATH)/style-check: $(GUI_SRCS) $(GUI_HDRS) $(TESTS_SRCS) $(TESTS_HDRS) $
 	@if [ "`git diff --name-only  | wc -l`" != "0" ]; then \
 		echo "Non compliant with style:"; \
 		git diff --name-only; \
+		git diff; \
 		exit 1;\
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,11 @@ GUI_HDRS+=$(shell find src/UI -iname '*.h*')
 GUI_PRO+=$(shell find src/UI -iname '*.pro')
 
 COMMON_SRCS=$(shell find src/common -iname '*.cpp')
+COMMON_HDRS=$(shell find src/common -iname '*.h*')
 COMMON_OBJS=$(addprefix $(BUILD_PATH)/,$(COMMON_SRCS:.cpp=.o))
 
 TESTS_SRCS=$(shell find src/tests -iname '*.cpp')
+TESTS_HDRS=$(shell find src/tests -iname '*.h*')
 TESTS_OBJS=$(addprefix $(BUILD_PATH)/,$(TESTS_SRCS:.cpp=.o))
 
 TEST_SCRIPTS=$(shell find src/tests -iname '*Tests')
@@ -120,8 +122,8 @@ $(BUILD_PATH)/run-dmrconfig-tests: $(TARGET_CLI) $(TEST_SCRIPTS)
 	./src/tests/btechTests examples/btech6x2.img.bak
 	@touch $@
 
-$(BUILD_PATH)/style-tests: $(GUI_SRCS) $(COMMON_SRCS) $(TESTS_SRCS)
-	clang-format -i  $^
+$(BUILD_PATH)/style-tests: $(GUI_SRCS) $(GUI_HDRS) $(TESTS_SRCS) $(TEST_HDRS) $(COMMON_SRCS) $(COMMON_HDRS)
+	clang-format -i $^
 
 check: $(BUILD_PATH)/run-tests $(BUILD_PATH)/run-dmrconfig-tests $(TARGET_GUI)
 	@echo -e "\e[32mAll Checks Passed\e[0m"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ GUI_PRO+=$(wildcard $(GUI_PATH)/*.pro)
 COMMON_PATH=src/common
 COMMON_INCPATHS=$(addprefix -I,$(shell find $(COMMON_PATH) -type d))
 COMMON_SRCS=$(wildcard $(COMMON_PATH)/*/*.cpp $(COMMON_PATH)/*.cpp)
-COMMON_HDRS=$(wildcard $(COMMON_OBJS)/*/*.hpp $(COMMON_OBJS)/*.hpp)
+COMMON_HDRS=$(wildcard $(COMMON_PATH)/*/*.hpp $(COMMON_PATH)/*.hpp)
 COMMON_OBJS=$(addprefix $(BUILD_PATH)/,$(COMMON_SRCS:.cpp=.o))
 
 TESTS_PATH=src/tests
@@ -128,8 +128,11 @@ $(BUILD_PATH)/run-dmrconfig-tests: $(TARGET_CLI) $(TEST_SCRIPTS)
 
 #Not required but good to have
 $(BUILD_PATH)/style-check: $(GUI_SRCS) $(GUI_HDRS) $(TESTS_SRCS) $(TESTS_HDRS) $(COMMON_SRCS) $(COMMON_HDRS)
-	clang-format -i $^ || true
-	@touch $@
+	clang-format --verbose $^ | grep Formatting
+	@if [ "`clang-format $^ | wc -l`" != "0" ]; then \
+		echo "Unformatted files"; \
+		exit 1;\
+	fi
 
 check: $(BUILD_PATH)/run-tests $(BUILD_PATH)/run-dmrconfig-tests $(TARGET_GUI)
 	@echo -e "\e[32mAll Checks Passed\e[0m"

--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,12 @@ $(BUILD_PATH)/run-dmrconfig-tests: $(TARGET_CLI) $(TEST_SCRIPTS)
 
 #Not required but good to have
 $(BUILD_PATH)/style-check: $(GUI_SRCS) $(GUI_HDRS) $(TESTS_SRCS) $(TESTS_HDRS) $(COMMON_SRCS) $(COMMON_HDRS)
-	clang-format --verbose $^ | grep Formatting
-	@if [ "`clang-format $^ | wc -l`" != "0" ]; then \
-		echo "Unformatted files"; \
-		exit 1;\
+	clang-format -i $^
+	if [ "`git diff --name-only  | wc -l`" != "0" ]; then \
+		git commit -a -m "Style compliance fixes"; \
+	  git remote -v; \
 	fi
+	@touch $@
 
 check: $(BUILD_PATH)/run-tests $(BUILD_PATH)/run-dmrconfig-tests $(TARGET_GUI)
 	@echo -e "\e[32mAll Checks Passed\e[0m"

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ $(BUILD_PATH)/style-check: $(GUI_SRCS) $(GUI_HDRS) $(TESTS_SRCS) $(TESTS_HDRS) $
 	if [ "`git diff --name-only  | wc -l`" != "0" ]; then \
 		git commit -a -m "Style compliance fixes"; \
 	  git remote -v; \
-		git push origin
+		git push origin; \
 	fi
 
 check: $(BUILD_PATH)/run-tests $(BUILD_PATH)/run-dmrconfig-tests $(TARGET_GUI)

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ DMRCONFIG_MAIN_OBJ=$(addprefix $(BUILD_PATH)/,$(DMRCONFIG_MAIN_SRC:.c=.o))
 
 GUI_PATH=src/UI
 GUI_SRCS=src/main.cpp
-GUI_SRCS+=$(shell find $(GUI_PATH) -iname '*.cpp')
-GUI_HDRS+=$(shell find $(GUI_PATH) -iname '*.hpp')
-GUI_PRO+=$(shell find $(GUI_PATH) -iname '*.pro')
+GUI_SRCS+=$(wildcard $(GUI_PATH)/*.cpp)
+GUI_HDRS+=$(wildcard $(GUI_PATH)/*.hpp)
+GUI_PRO+=$(wildcard $(GUI_PATH)/*.pro)
 
 COMMON_PATH=src/common
-COMMON_SRCS=$(shell find $(COMMON_PATH) -iname '*.cpp')
-COMMON_HDRS=$(shell find $(COMMON_PATH) -iname '*.hpp')
+COMMON_SRCS=$(wildcard $(COMMON_PATH)/*/*.cpp)
+COMMON_HDRS=$(wildcard $(COMMON_OBJS)/*/*.hpp)
 COMMON_OBJS=$(addprefix $(BUILD_PATH)/,$(COMMON_SRCS:.cpp=.o))
 
 INCPATHS         += -Isrc -I$(DMRCONFIG_PATH) -I$(GUI_PATH) -I$(COMMON_PATH) -Isrc/common/BSONDoc -Isrc/tests/SimpleTest
@@ -38,8 +38,9 @@ LIBMONGOCINCPATH += $(shell pkg-config --cflags libmongoc-1.0)
 LIBUSBPATH       += $(shell pkg-config --cflags libusb-1.0)
 LINCPATHS        += $(LIBMONGOCINCPATH) $(LIBUSBPATH)
 
-TESTS_SRCS=$(shell find src/tests -iname '*.cpp')
-TESTS_HDRS=$(shell find src/tests -iname '*.h*')
+TESTS_PATH=src/tests
+TESTS_SRCS=$(wildcard $(TESTS_PATH)/*.cpp)
+TESTS_HDRS=$(wildcard $(TESTS_PATH/*.h*)
 TESTS_OBJS=$(addprefix $(BUILD_PATH)/,$(TESTS_SRCS:.cpp=.o))
 
 TEST_SCRIPTS=$(shell find src/tests -iname '*Tests')

--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ $(BUILD_PATH)/style-check: $(GUI_SRCS) $(GUI_HDRS) $(TESTS_SRCS) $(TESTS_HDRS) $
 	if [ "`git diff --name-only  | wc -l`" != "0" ]; then \
 		git commit -a -m "Style compliance fixes"; \
 	  git remote -v; \
+		git push origin
 	fi
-	@touch $@
 
 check: $(BUILD_PATH)/run-tests $(BUILD_PATH)/run-dmrconfig-tests $(TARGET_GUI)
 	@echo -e "\e[32mAll Checks Passed\e[0m"

--- a/src/UI/ConfBlockWidget.cpp
+++ b/src/UI/ConfBlockWidget.cpp
@@ -200,7 +200,7 @@ void ConfBlockWidget::removeValueAction()
     ConfBlock::replaceRegex(cellText, "^" + textToRemove + ",", "");
     ConfBlock::replaceRegex(cellText, "," + textToRemove + ",", ",");
     ConfBlock::replaceRegex(cellText, "," + textToRemove + "(,|$)", "");
-    if(cellText == "")
+    if (cellText == "")
       cellText = "-";
     item->setText(cellText.c_str());
     _confBlock.getRows()[item->row()][item->column()] = cellText;

--- a/src/UI/ConfFileWidget.cpp
+++ b/src/UI/ConfFileWidget.cpp
@@ -48,7 +48,7 @@ void ConfFileWidget::updateTabs()
   _confBlockWidgets.clear();
   _tabWidget->clear();
 
-  for (auto& pair: _confFile.getConfBlocks())
+  for (auto& pair : _confFile.getConfBlocks())
   {
     auto& confBlock = pair.second;
     auto temp = new ConfBlockWidget(confBlock, this);

--- a/src/UI/MainWindow.cpp
+++ b/src/UI/MainWindow.cpp
@@ -246,4 +246,3 @@ void MainWindow::loadFile(const QString& filename)
   takeCentralWidget();
   setCentralWidget(_confFileWidget);
 }
-

--- a/src/common/BSONDoc/BSONDoc.cpp
+++ b/src/common/BSONDoc/BSONDoc.cpp
@@ -155,7 +155,8 @@ bool BSONDoc::getString(std::string& result, const std::string& path) const
   {
     switch (bson_iter_type(&baz))
     {
-      case BSON_TYPE_OID: {
+      case BSON_TYPE_OID:
+      {
         char str[25];
         const bson_oid_t* oid = bson_iter_oid(&baz);
         bson_oid_to_string(oid, str);

--- a/src/common/ConfFile.cpp
+++ b/src/common/ConfFile.cpp
@@ -145,4 +145,3 @@ void ConfFile::downloadFile(const std::string& filename)
   radio_print_config(conf, 1);
   fclose(conf);
 }
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,8 @@
 
 #include "MainWindow.hpp"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char* argv[])
+{
   char setting[] = "QT_MESSAGE_PATTERN=%{file}:%{line} - %{message}";
   putenv(setting);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,8 +9,7 @@
 
 #include "MainWindow.hpp"
 
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
   char setting[] = "QT_MESSAGE_PATTERN=%{file}:%{line} - %{message}";
   putenv(setting);
 


### PR DESCRIPTION
Close #19 

Not required for compilation but will update files in tree if clang-format is available.

```
make build/style-check
```

Will tell you what is non compliant with the .clang-format and fix them in place.

It is now part of the github actions so if the build system you use doesn't have clang-format you 'll find out from the checks in the PR.