### PR TITLE
Remove device.img when done

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ $(BUILD_PATH)/run-unit-tests: $(TARGET_TESTS)
 
 $(BUILD_PATH)/run-new-conf-tests: $(BUILD_PATH)/run-unit-tests $(TARGET_CLI)
 	./$(TARGET_CLI) -c examples/btech6x2.img.bak build/btechSimpleOpen.conf
+	rm device.img
 
 $(BUILD_PATH)/run-net-tests: $(TARGET_TESTS)
 	QT_QPA_PLATFORM='offscreen' $^ -n


### PR DESCRIPTION
remove a rogue device.img after running build/run-new-conf-test